### PR TITLE
Initial Proposal for the About Tab.

### DIFF
--- a/Razor/UI/Layouts/MainLayout.razor
+++ b/Razor/UI/Layouts/MainLayout.razor
@@ -48,8 +48,6 @@
 		</ul>
 	</div>
 </div>
-<div class="row">
-	<div class="col">
-		@Body
-	</div>
+<div class="blazor-content">
+	@Body
 </div>

--- a/Razor/UI/Pages/About.razor
+++ b/Razor/UI/Pages/About.razor
@@ -1,11 +1,46 @@
 @page "/about"
 
-<h1>About</h1>
-
-<div>
-	<p>About Page</p>
+<div class="row">
+	<div class="col">
+		<a href="https://razorce.com/help/" style="display:flex; justify-content:right; margin:5px">Need Help?</a>
+	</div>
+</div>
+<div class="row">
+	<div class="col">
+		<h1 class="center-content" style="font-weight:bold; font-size:24px; margin-top:10px">Razor @razorVersion</h1>
+		
+	</div>
+</div>
+<div class="row">
+	<div class="col">
+		<p class="center-content" style="font-size:15px">Community Edition</p>
+	</div>
+</div>
+<div class="row">
+	<div class="col">
+		<span class="center-content" >For Feedback, support and the latest releases please vist:</span>
+		<a class="center-content" href="https://razorce.com/">https://razorce.com</a>
+		<a class="center-content" href="https://github.com/markdwags/Razor">https://github.com/markdwags/Razor</a>
+	</div>
+</div>
+<div class="row">
+	<div class="col">
+		<span class="center-content" style="margin-top:20px; font-weight:bold"> Razor was designed by Zippy, modified and maintained by Quick</span>
+		<span class="center-content" style="font-weight:bold">Major design changes including ClassicUO integration by Jaedan</span>
+		<span class="center-content" style="font-weight:bold">Cross-platform implementation by DarkLotus</span>
+		<span class="center-content" style="font-weight:bold">UI Revamp by Jaeden and Greens</span>
+	</div>
 </div>
 
 @code {
 
+	System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
+	System.Diagnostics.FileVersionInfo fvi;
+	string razorVersion;
+
+	protected override void OnInitialized()
+	{
+		fvi = System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location);
+		razorVersion = fvi.FileVersion;
+	}
 }

--- a/Razor/wwwroot/css/app.css
+++ b/Razor/wwwroot/css/app.css
@@ -32,3 +32,13 @@ html, body {
     padding: 2px;
     margin: 0px;
 }
+
+.blazor-content {
+    background: #F0F0F0;
+    font-size: 13px;
+}
+
+.center-content {
+    display: flex;
+    justify-content: center;
+}

--- a/Razor/wwwroot/index.html
+++ b/Razor/wwwroot/index.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-    <div class="container window" id="app"></div>
+    <div id="app"></div>
 
     <script src="_framework/blazor.webview.js"></script>
     <script src="js/bootstrap.min.js"></script>


### PR DESCRIPTION
In th MainLayout.razor I got rid of the row col because we only have one content element so there is no need to structure it in rows and coloumns. Instead I created a new content class where we can define the default background color and font size for blazer content.

The About.razor page is quite special when it comes to text formatting so I added it directly into the page since it won't be reused anywhere else.

In the index.html I removed the **container** and **window** class not entirely sure what it does but without those the resizing issue of the tab navigation is fixed. 